### PR TITLE
Fix outdated tests

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -8,9 +8,9 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('should display welcome message', async () => {
+  it('should display the header logo text', async () => {
     await page.navigateTo();
-    expect(await page.getTitleText()).toEqual('GetItems app is running!');
+    expect(await page.getHeaderLogoText()).toEqual('Disway');
   });
 
   afterEach(async () => {

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -5,7 +5,7 @@ export class AppPage {
     return browser.get(browser.baseUrl);
   }
 
-  async getTitleText(): Promise<string> {
-    return element(by.css('app-root .content span')).getText();
+  async getHeaderLogoText(): Promise<string> {
+    return element(by.css('app-root header .logo')).getText();
   }
 }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,16 +20,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'GetItems'`, () => {
+  it('should store submitted form data on handleSubmit', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('GetItems');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain('GetItems app is running!');
+    app.handleSubmit({ product: 'P', brand: 'B' });
+    expect(app.formData).toEqual({ product: 'P', brand: 'B' });
   });
 });


### PR DESCRIPTION
## Summary
- update `AppComponent` unit tests to reflect current component state
- correct e2e tests to check for the logo text instead of a removed title

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad8c85dac8322830293e60b4a3e5c